### PR TITLE
Add a fallback language strategy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,3 @@ before_script:
 
 script:
   - make test
-
-notifications:
-  email: false
-  webhooks: http://finebot.herokuapp.com/hubot/travis/?room=30565_platform@conf.hipchat.com

--- a/taal/__init__.py
+++ b/taal/__init__.py
@@ -28,11 +28,13 @@ class TranslationStrategies(object):
     NONE_VALUE = strategies.NoneStrategy
     SENTINEL_VALUE = strategies.SentinelStrategy
     DEBUG_VALUE = strategies.DebugStrategy
+    EN_FALLBACK = strategies.ENFallbackStrategy
 
     _valid_strategies = (
         NONE_VALUE,
         SENTINEL_VALUE,
         DEBUG_VALUE,
+        EN_FALLBACK,
     )
 
     @classmethod

--- a/taal/__init__.py
+++ b/taal/__init__.py
@@ -21,26 +21,13 @@ except:  # pragma: no cover
 
 NULL = None  # for pep8
 
-TRANSLATION_MISSING = strategies.SentinelStrategy.TRANSLATION_MISSING
+TRANSLATION_MISSING = strategies.TRANSLATION_MISSING
 
 
 class TranslationStrategies(object):
-    NONE_VALUE = strategies.NoneStrategy
-    SENTINEL_VALUE = strategies.SentinelStrategy
-    DEBUG_VALUE = strategies.DebugStrategy
-    EN_FALLBACK = strategies.ENFallbackStrategy
-
-    _valid_strategies = (
-        NONE_VALUE,
-        SENTINEL_VALUE,
-        DEBUG_VALUE,
-        EN_FALLBACK,
-    )
-
-    @classmethod
-    def validate(cls, strategy):
-        if strategy not in cls._valid_strategies:
-            raise ValueError(u"Invalid strategy `{}`".format(strategy))
+    NONE_VALUE = strategies.NoneStrategy()
+    SENTINEL_VALUE = strategies.SentinelStrategy()
+    DEBUG_VALUE = strategies.DebugStrategy()
 
 
 class Translator(object):
@@ -80,8 +67,6 @@ class Translator(object):
     ):
         self.model = model
         self.session = session
-
-        self.strategies.validate(strategy)
         self.strategy = strategy
 
         if callable(language):
@@ -118,16 +103,11 @@ class Translator(object):
         can also take a 'structure' (currently lists, tuples, and dicts)
         and recursively translate any TranslatableStrings found.
         """
-        if strategy is not None:
-            self.strategies.validate(strategy)
-
         if strategy is None:
-            strategy_cls = self.strategy
-        else:
-            strategy_cls = strategy
+            strategy = self.strategy
 
         return (
-            strategy_cls(self.language, self.model, self.session)
+            strategy.bind_params(self.language, self.model, self.session)
             .recursive_translate(translatable)
         )
 

--- a/taal/kaiso/__init__.py
+++ b/taal/kaiso/__init__.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 
 from kaiso.attributes import String
 
-from taal import is_translatable_value
 from taal.constants import PLACEHOLDER, TRANSPARENT_VALUES, PlaceholderValue
+from taal.translatablestring import is_translatable_value
 
 TYPE_CONTEXT = "taal:kaiso_type"
 

--- a/taal/kaiso/manager.py
+++ b/taal/kaiso/manager.py
@@ -5,12 +5,14 @@ from kaiso.exceptions import DeserialisationError
 from kaiso.persistence import Manager as KaisoManager
 from kaiso.types import PersistableType, get_type_id
 
-from taal import (
-    TranslatableString as TaalTranslatableString, is_translatable_value)
 from taal.constants import PLACEHOLDER
 from taal.exceptions import NoTranslatorRegistered
 from taal.kaiso import TranslatableString, TYPE_CONTEXT
 from taal.kaiso.types import get_context, get_message_id
+from taal.translatablestring import (
+    is_translatable_value,
+    TranslatableString as TaalTranslatableString,
+)
 
 
 MISSING = object()

--- a/taal/kaiso/types.py
+++ b/taal/kaiso/types.py
@@ -3,7 +3,7 @@ import json
 from kaiso.types import get_type_id
 from kaiso.serialize import object_to_db_value
 
-from taal import TranslatableString
+from taal.translatablestring import TranslatableString
 
 
 def get_context(manager, obj, attribute_name):

--- a/taal/sqlalchemy/events.py
+++ b/taal/sqlalchemy/events.py
@@ -3,12 +3,14 @@ from weakref import WeakKeyDictionary
 from sqlalchemy import event, inspect
 from sqlalchemy.orm.attributes import get_history
 
-from taal import (
-    TranslatableString as TaalTranslatableString, is_translatable_value)
 from taal.sqlalchemy.types import (
     TranslatableString, pending_translatables, make_from_obj,
     translatable_models)
 from taal.constants import PlaceholderValue
+from taal.translatablestring import (
+    is_translatable_value,
+    TranslatableString as TaalTranslatableString,
+)
 
 
 translator_registry = WeakKeyDictionary()

--- a/taal/sqlalchemy/types.py
+++ b/taal/sqlalchemy/types.py
@@ -5,8 +5,10 @@ from sqlalchemy import event, inspect, types
 from sqlalchemy.orm.mapper import Mapper
 
 from taal.constants import PLACEHOLDER, PlaceholderValue
-from taal import (
-    TranslatableString as TaalTranslatableString, is_translatable_value)
+from taal.translatablestring import (
+    is_translatable_value,
+    TranslatableString as TaalTranslatableString,
+)
 
 
 CONTEXT_TEMPLATE = "taal:sa_field:{}:{}"

--- a/taal/strategies.py
+++ b/taal/strategies.py
@@ -1,3 +1,6 @@
+from taal.translatablestring import TranslatableString
+
+
 class Strategy(object):
 
     def __init__(self, cache, language):
@@ -12,6 +15,22 @@ class Strategy(object):
 
     def translation_missing(self, translatable):
         raise NotImplementedError
+
+    def recursive_translate(self, translatable):
+        if isinstance(translatable, TranslatableString):
+            return self.translate(translatable)
+        elif isinstance(translatable, dict):
+            return dict(
+                (key, self.recursive_translate(val))
+                for key, val in translatable.iteritems()
+            )
+        elif isinstance(translatable, list):
+            return [self.recursive_translate(item) for item in translatable]
+        elif isinstance(translatable, tuple):
+            return tuple(self.recursive_translate(item)
+                         for item in translatable)
+        else:
+            return translatable
 
 
 class NoneStrategy(Strategy):

--- a/taal/strategies.py
+++ b/taal/strategies.py
@@ -1,0 +1,38 @@
+class Strategy(object):
+
+    def __init__(self, cache, language):
+        self.cache = cache
+        self.language = language
+
+    def translate(self, translatable):
+        try:
+            return self.cache[(translatable.context, translatable.message_id)]
+        except KeyError:
+            return self.translation_missing(translatable)
+
+    def translation_missing(self, translatable):
+        raise NotImplementedError
+
+
+class NoneStrategy(Strategy):
+
+    def translation_missing(self, translatable):
+        return None
+
+
+class SentinelStrategy(Strategy):
+
+    TRANSLATION_MISSING = "<TranslationMissing sentinel>"
+
+    def translation_missing(self, translatable):
+        return self.TRANSLATION_MISSING
+
+
+class DebugStrategy(Strategy):
+
+    def get_debug_translation(self, translatable):
+        return u"[Translation missing ({}, {}, {})]".format(
+            self.language, translatable.context, translatable.message_id)
+
+    def translation_missing(self, translatable):
+        return self.get_debug_translation(translatable)

--- a/taal/translatablestring.py
+++ b/taal/translatablestring.py
@@ -1,0 +1,24 @@
+class TranslatableString(object):
+    """
+    Placeholder for a string to be translated
+
+    Holds metadata, ``context`` and ``message_id``, and optionally
+    a string ``pending_value``
+    """
+
+    def __init__(self, context=None, message_id=None, pending_value=None):
+        self.context = context
+        self.message_id = message_id
+        self.pending_value = pending_value
+
+    def __repr__(self):
+        return "<TranslatableString: ({}, {}, {})>".format(
+            self.context, self.message_id, self.pending_value)
+
+    def __eq__(self, other):
+        if not isinstance(other, TranslatableString):
+            return False
+
+        self_data = (self.context, self.message_id, self.pending_value)
+        other_data = (other.context, other.message_id, other.pending_value)
+        return self_data == other_data

--- a/taal/translatablestring.py
+++ b/taal/translatablestring.py
@@ -19,8 +19,11 @@ class TranslatableString(object):
         self.pending_value = pending_value
 
     def __repr__(self):
-        return "<TranslatableString: ({}, {}, {})>".format(
-            self.context, self.message_id, self.pending_value)
+        return u"<TranslatableString: ({}, {}, {})>".format(
+            self.context,
+            self.message_id,
+            self.pending_value,
+        ).encode('utf8')
 
     def __eq__(self, other):
         if not isinstance(other, TranslatableString):

--- a/taal/translatablestring.py
+++ b/taal/translatablestring.py
@@ -1,3 +1,10 @@
+from taal.constants import TRANSPARENT_VALUES
+
+
+def is_translatable_value(value):
+    return value not in TRANSPARENT_VALUES
+
+
 class TranslatableString(object):
     """
     Placeholder for a string to be translated

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,8 +102,11 @@ def clean_engine(request):
         database = connection_url.database
         connection_url.database = None  # may not exist, so don't connect to it
         engine = create_engine(connection_url)
-        query = 'DROP DATABASE IF EXISTS {0}; CREATE DATABASE {0}'.format(
-            database)
+        query = (
+            'DROP DATABASE IF EXISTS {0}; '
+            'CREATE DATABASE {0} CHARACTER SET utf8;'
+            .format(database)
+        )
         engine.execute(query)
 
     engine = create_engine(connection_string)

--- a/tests/kaiso/test_manager.py
+++ b/tests/kaiso/test_manager.py
@@ -3,12 +3,13 @@ from __future__ import absolute_import
 from kaiso.exceptions import DeserialisationError
 import pytest
 
-from taal import TranslatableString, Translator
+from taal import Translator
 from taal.constants import PLACEHOLDER, PlaceholderValue
 from taal.exceptions import NoTranslatorRegistered
 from taal.kaiso import TYPE_CONTEXT
 from taal.kaiso.manager import collect_translatables
 from taal.kaiso.types import get_context, get_message_id
+from taal.translatablestring import TranslatableString
 
 from tests.models import Translation, CustomFieldsEntity
 

--- a/tests/kaiso/test_types.py
+++ b/tests/kaiso/test_types.py
@@ -4,8 +4,9 @@ import json
 
 import pytest
 
-from taal import TranslatableString, Translator
+from taal import Translator
 from taal.kaiso.types import get_context, get_message_id, make_from_obj
+from taal.translatablestring import TranslatableString
 
 from tests.models import (
     CustomFieldsEntity, NoCustomFieldsEntity, Translation,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 
 import pytest
 
-from taal import Translator, TranslatableString
+from taal import Translator
+from taal.translatablestring import TranslatableString
 
 from tests.models import Translation
 

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -9,14 +9,13 @@ from sqlalchemy import Column, Text, Integer
 from sqlalchemy.exc import OperationalError, StatementError
 from sqlalchemy.ext.declarative import declarative_base
 
-from taal import (
-    Translator, TranslatableString, is_translatable_value, TRANSLATION_MISSING,
-)
+from taal import Translator, TRANSLATION_MISSING
 from tests.models import (
     Model, RequiredModel, Translation, Parent, Child, RenamedColumn)
 from taal.sqlalchemy.events import flush_log, load
 from taal.sqlalchemy.types import make_from_obj
 from taal.constants import PlaceholderValue
+from taal.translatablestring import TranslatableString, is_translatable_value
 
 
 Base = declarative_base()

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -54,6 +54,28 @@ class TestStrategies(object):
         translation = translator.translate(translatable)
         assert "[Translation missing" in translation
 
+    def test_en_fallback(self, session):
+        translation = Translation(
+            context=SAMPLE_CONTEXT,
+            message_id=SAMPLE_MESSAGE_ID,
+            language='en',
+            value='en fallback',
+        )
+        session.add(translation)
+        session.commit()
+        translator = Translator(
+            Translation,
+            session,
+            SAMPLE_LANGUAGE,
+            strategy=Translator.strategies.EN_FALLBACK,
+        )
+
+        translatable = TranslatableString(
+            context=SAMPLE_CONTEXT, message_id=SAMPLE_MESSAGE_ID)
+
+        translation = translator.translate(translatable)
+        assert translation == 'en fallback'
+
     def test_override(self, session):
         translator = Translator(
             Translation,

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -6,6 +6,7 @@ import pytest
 
 from taal import Translator, TRANSLATION_MISSING
 from taal.translatablestring import TranslatableString
+from taal.strategies import FallbackLangStrategy
 
 from tests.models import Translation
 
@@ -63,11 +64,12 @@ class TestStrategies(object):
         )
         session.add(translation)
         session.commit()
+        en_fallback_strategy = FallbackLangStrategy('en')
         translator = Translator(
             Translation,
             session,
             SAMPLE_LANGUAGE,
-            strategy=Translator.strategies.EN_FALLBACK,
+            strategy=en_fallback_strategy,
         )
 
         translatable = TranslatableString(
@@ -106,23 +108,3 @@ class TestStrategies(object):
         translator.save_translation(translatable)
 
         assert session.query(Translation).count() == 0
-
-    def test_invalid(self):
-        with pytest.raises(ValueError) as exc:
-            Translator(
-                Translation,
-                session=None,
-                language=None,
-                strategy='invalid ಠ_ಠ',
-            )
-        assert 'Invalid strategy `invalid ಠ_ಠ`' in unicode(exc)
-
-    def test_invalid_override(self):
-        translator = Translator(
-            Translation,
-            session=None,
-            language=None,
-        )
-        with pytest.raises(ValueError) as exc:
-            translator.translate(None, strategy='invalid ಠ_ಠ')
-        assert 'Invalid strategy `invalid ಠ_ಠ`' in unicode(exc)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -4,7 +4,8 @@ from __future__ import absolute_import, unicode_literals
 
 import pytest
 
-from taal import Translator, TranslatableString, TRANSLATION_MISSING
+from taal import Translator, TRANSLATION_MISSING
+from taal.translatablestring import TranslatableString
 
 from tests.models import Translation
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from taal import TranslatableString
+from taal.translatablestring import TranslatableString
 
 
 class TestComparison(object):


### PR DESCRIPTION
Add a Strategy that falls back to another language when a translation is not found.
I had to move a fair bit of code around to enable this. I've tried to structure this in a way that it can be reviewed commit by commit. 