### PR TITLE
Fix breaking change between master and 0.8.2

### DIFF
--- a/taal/__init__.py
+++ b/taal/__init__.py
@@ -127,7 +127,7 @@ class Translator(object):
                     translatable, TRANSLATION_MISSING))
 
         if self.strategy == self.strategies.DEBUG_VALUE:
-            debug_value = self._get_debug_translation(translatable)
+            debug_value = self.strategy.get_debug_translation(translatable)
             if translatable.pending_value == debug_value:
                 return
 

--- a/taal/__init__.py
+++ b/taal/__init__.py
@@ -95,10 +95,6 @@ class Translator(object):
         else:
             raise BindError("Unknown target {}".format(target))
 
-    def _get_debug_translation(self, translatable):
-        return u"[Translation missing ({}, {}, {})]".format(
-            self.language, translatable.context, translatable.message_id)
-
     def translate(self, translatable, strategy=None, cache=None):
         """
         Translate ``TranslatableString`` by looking up a translation

--- a/taal/__init__.py
+++ b/taal/__init__.py
@@ -123,7 +123,8 @@ class Translator(object):
                     translatable, TRANSLATION_MISSING))
 
         if self.strategy == self.strategies.DEBUG_VALUE:
-            debug_value = self.strategy.get_debug_translation(translatable)
+            debug_value = self.strategy.get_debug_translation(
+                self.language, translatable)
             if translatable.pending_value == debug_value:
                 return
 

--- a/taal/__init__.py
+++ b/taal/__init__.py
@@ -13,6 +13,9 @@ from sqlalchemy.sql.expression import and_, or_, desc
 
 from taal import strategies
 from taal.exceptions import BindError
+# Backward compatible import
+from taal.translatablestring import (  # noqa
+    TranslatableString, is_translatable_value)
 
 try:
     VERSION = __import__('pkg_resources').get_distribution('taal').version

--- a/taal/strategies.py
+++ b/taal/strategies.py
@@ -25,9 +25,9 @@ class Strategy(object):
                 (translatable.context, translatable.message_id, self.language)
             ]
         except KeyError:
-            return self.translation_missing(translatable, cache)
+            return self.translation_missing(self.language, translatable, cache)
 
-    def translation_missing(self, translatable, cache):
+    def translation_missing(self, language, translatable, cache):
         raise NotImplementedError
 
     def recursive_translate(self, translatable, cache=None):
@@ -116,25 +116,25 @@ class Strategy(object):
 
 class NoneStrategy(Strategy):
 
-    def translation_missing(self, translatable, cache):
+    def translation_missing(self, language, translatable, cache):
         return None
 
 
 class SentinelStrategy(Strategy):
 
-    def translation_missing(self, translatable, cache):
+    def translation_missing(self, language, translatable, cache):
         return TRANSLATION_MISSING
 
 
 class DebugStrategy(Strategy):
 
-    def get_debug_translation(self, translatable):
+    def get_debug_translation(self, language, translatable):
         return "[Translation missing ({}, {}, {})]".format(
-            self.language, translatable.context, translatable.message_id
+            language, translatable.context, translatable.message_id
         ).decode('utf-8')
 
-    def translation_missing(self, translatable, cache):
-        return self.get_debug_translation(translatable)
+    def translation_missing(self, language, translatable, cache):
+        return self.get_debug_translation(language, translatable)
 
 
 class FallbackLangStrategy(Strategy):
@@ -142,7 +142,7 @@ class FallbackLangStrategy(Strategy):
     def __init__(self, fallback_lang):
         self.fallback_lang = fallback_lang
 
-    def translation_missing(self, translatable, cache):
+    def translation_missing(self, language, translatable, cache):
         try:
             return cache[(
                 translatable.context,

--- a/taal/translatablestring.py
+++ b/taal/translatablestring.py
@@ -19,11 +19,11 @@ class TranslatableString(object):
         self.pending_value = pending_value
 
     def __repr__(self):
-        return u"<TranslatableString: ({}, {}, {})>".format(
+        return "<TranslatableString: ({}, {}, {})>".format(
             self.context,
             self.message_id,
             self.pending_value,
-        ).encode('utf8')
+        )
 
     def __eq__(self, other):
         if not isinstance(other, TranslatableString):

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -102,7 +102,7 @@ class TestStrategies(object):
 
         translatable = TranslatableString(
             context=SAMPLE_CONTEXT, message_id=SAMPLE_MESSAGE_ID)
-        debug_value = translator._get_debug_translation(translatable)
+        debug_value = translator.strategy.get_debug_translation(translatable)
         translatable.pending_value = debug_value
 
         translator.save_translation(translatable)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -10,9 +10,9 @@ from taal.strategies import FallbackLangStrategy
 
 from tests.models import Translation
 
-SAMPLE_CONTEXT = 'context ಠ_ಠ'
-SAMPLE_MESSAGE_ID = 'message_id ಠ_ಠ'
-SAMPLE_LANGUAGE = 'language ಠ_ಠ'
+SAMPLE_CONTEXT = 'context ಠ_ಠ'.encode('utf-8')
+SAMPLE_MESSAGE_ID = 'message_id ಠ_ಠ'.encode('utf-8')
+SAMPLE_LANGUAGE = 'language ಠ_ಠ'.encode('utf-8')
 
 
 @pytest.mark.usefixtures('manager')
@@ -59,8 +59,8 @@ class TestStrategies(object):
         translation = Translation(
             context=SAMPLE_CONTEXT,
             message_id=SAMPLE_MESSAGE_ID,
-            language='en',
-            value='en fallback',
+            language='en'.encode('utf-8'),
+            value='en fallback ಠ_ಠ'.encode('utf-8'),
         )
         session.add(translation)
         session.commit()
@@ -76,7 +76,7 @@ class TestStrategies(object):
             context=SAMPLE_CONTEXT, message_id=SAMPLE_MESSAGE_ID)
 
         translation = translator.translate(translatable)
-        assert translation == 'en fallback'
+        assert translation == 'en fallback ಠ_ಠ'
 
     def test_override(self, session):
         translator = Translator(


### PR DESCRIPTION
**Edit**: this PR was initialy about the import only. Now, it's also about the str/unicode breaking change that I would like to revert.

To this date, latest commit from master break backward compatibility with v0.8.2 because `TranslatableString` has been moved into `taal.translatablestring`. If I'm totally fine with this class moved into its own sub-module, I wish to keep this backward compatibility so that I don't have to update a huge codebase.